### PR TITLE
prevent IndexError

### DIFF
--- a/gpt2_config.py
+++ b/gpt2_config.py
@@ -43,7 +43,7 @@ class Gpt2Generator(object):
             checkpoint_dir=MODEL_DIR,
             run_name=MODEL_NAME
         )
-        titles = [title.split(maxsplit=1)[1] for title in titles]
+        titles = [title.split(maxsplit=1)[-1] for title in titles]
         # Escape user mentions to prevent spamming them
         titles = [title.replace('u/', '/u/') for title in titles]
         return titles


### PR DESCRIPTION
Getting the last index instead of the 2nd index works in cases when there isn't a second index